### PR TITLE
Add options to fix the session cookie max age.

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Here are the details of available options.
 | MESOS\_TERM\_MESOS\_STATE\_CACHE\_TIME  | Time in seconds before invalidating the cache containing Mesos state.                    |
 | MESOS\_TERM\_NODE\_ENV                  | Must be "production" for express to run in production mode.                              |
 | MESOS\_TERM\_SESSION\_SECRET            | Secret used to encrypt session cookie.                                                   |
+| MESOS\_TERM\_SESSION\_MAX_AGE_SEC       | The session cookie will expire after this amount of time. (default: 3h)                  |
 | MESOS\_TERM\_SUPER\_ADMINS              | Comma-separated list of LDAP users and groups having all rights on all containers.       |
 | MESOS\_TERM\_CA\_FILE                   | CA file to connect to Mesos agent  in pem format.                                        |
 | MESOS\_TERM\_MESOS\_AGENT\_PRINCIPAL    | The principal Mesos term uses to connect to the Mesos agent.                             |

--- a/src/env_vars.ts
+++ b/src/env_vars.ts
@@ -7,10 +7,10 @@ function getOrExit(varName: string): string {
   process.exit(1);
 }
 
-function getOrElse(varName: string, defaultValue: string): string {
+function getOrElse<T extends string | number>(varName: string, defaultValue: T): T {
   const v = process.env[varName];
   if (v) {
-    return v;
+    return v as T;
   }
   else {
     return defaultValue;
@@ -28,6 +28,7 @@ export interface EnvVars {
   MESOS_MASTER_URL: string;
   MESOS_STATE_CACHE_TIME: number;
   SESSION_SECRET: string;
+  SESSION_MAX_AGE_SEC: number;
   SUPER_ADMINS: string[];
   ALLOWED_TASK_ADMINS: string[];
 
@@ -62,6 +63,7 @@ function parseAllowedTaskAdmins() {
 
 export const env: EnvVars = {
   SESSION_SECRET: getOrExit('MESOS_TERM_SESSION_SECRET'),
+  SESSION_MAX_AGE_SEC: getOrElse('MESOS_TERM_SESSION_MAX_AGE_SEC', 3 * 3600), // 3h by default.
   JWT_SECRET: getOrExit('MESOS_TERM_JWT_SECRET'),
   SUPER_ADMINS: getSuperAdmins(),
   ALLOWED_TASK_ADMINS: parseAllowedTaskAdmins(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ const sessionOptions: session.SessionOptions = {
   secret: env.SESSION_SECRET,
   resave: false,
   saveUninitialized: false,
-  cookie: { secure: false }
+  cookie: { secure: false, maxAge: env.SESSION_MAX_AGE_SEC * 1000.0 }
 };
 
 if (app.get('env') === 'production') {


### PR DESCRIPTION
The session cookies had a session scope so they were live as long as the
browser was still open. It's safer to apply an hard limit to the amount
of time a cookie is valid. The default lifetime of a cookie now becomes
3 hours and can be overriden with the MESOS_TERM_SESSION_MAX_AGE_SEC env
variable.