### PR TITLE
Allow anyone to delegate access 

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Here are the details of available options.
 | MESOS\_TERM\_ENVIRONMENT                | List of environment variable to enrich the shell with (NAME=value, colon separated)      |
 | MESOS\_TERM\_ENABLE\_PER\_APP\_ADMINS   | If 'true', application administrators can be declared with the Mesos label MESOS\_TERM\_DEBUG\_GRANTED\_TO label. It means those users can log into the application containers. An example is provided below. (Default: false) |
 | MESOS\_TERM\_ALLOWED\_TASK\_ADMINS      | White list of application administrators (users or groups) allowed to override application configuration through Mesos label |
-| MESOS\_TERM\_ENABLE\_RIGHTS\_DELEGATION | If 'true', super administrators can delegate rights to log into one specific container to one person for a certain amount of time. (Default: false) |
+| MESOS\_TERM\_ENABLE\_RIGHTS\_DELEGATION | If 'true', users with access can delegate rights to log into one specific container to one person for a certain amount of time. (Default: false) |
 | MESOS\_TERM\_JWT\_SECRET                | Secret used to generate and validate JWT tokens.                                         |
 | MESOS\_TERM\_LDAP\_BASE\_DN             | Base distinguished name from which to search users for authentication.                   |
 | MESOS\_TERM\_LDAP\_PASSWORD             | Password of the LDAP user to bind against LDAP server.                                   |

--- a/src/express_helpers.ts
+++ b/src/express_helpers.ts
@@ -42,3 +42,18 @@ export function SuperAdminsOnly(
   }
   res.status(403).send();
 }
+
+// middleware to allow anyone logged
+export function AllowAnyOne(
+  req: Request,
+  res: Express.Response,
+  next: Express.NextFunction) {
+
+  const user = req.user as User;
+
+  if (user.cn && user.memberOf) {
+    next();
+    return;
+  }
+  res.status(403).send();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import { DelegateGet, DelegatePost } from './controllers/delegate';
 import config from './controllers/config';
 import sandbox from './controllers/sandbox';
 
-import { setup, SuperAdminsOnly } from './express_helpers';
+import { setup, SuperAdminsOnly, AllowAnyOne } from './express_helpers';
 import { BasicAuth } from './authentication';
 import { AuthenticatedLogger, AnonymousLogger } from './logger';
 
@@ -60,8 +60,8 @@ sandbox(app);
 app.get('/api/config', config);
 
 if (env.AUTHORIZATIONS_ENABLED && env.ENABLE_RIGHTS_DELEGATION) {
-  app.get('/api/delegate', SuperAdminsOnly, DelegateGet);
-  app.post('/api/delegate', SuperAdminsOnly, DelegatePost);
+  app.get('/api/delegate', AllowAnyOne, DelegateGet);
+  app.post('/api/delegate', AllowAnyOne, DelegatePost);
 }
 
 app.get('*', (req, res) => {


### PR DESCRIPTION
Before this patch, only super admins could delegate access to a given
container.
Now anyone with access to a container can delegate access.
The boolean ENABLE_RIGHTS_DELEGATION takes all its meaning now.