### PR TITLE
Support authenticated sandbox

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        suite: [standard, noauth, noadmin, taskadmins]
+        suite: [standard, noauth, noadmin, taskadmins, fullauthentication]
     steps:
       - uses: actions/checkout@v2
       - name: Prepare docker compose override if any

--- a/tests/fullauthentication/00-setup.ts
+++ b/tests/fullauthentication/00-setup.ts
@@ -1,0 +1,3 @@
+import { setupSuite } from "../00-init";
+
+setupSuite();

--- a/tests/fullauthentication/app6.ts
+++ b/tests/fullauthentication/app6.ts
@@ -1,0 +1,49 @@
+import AppsHelpers = require('../apps_helpers');
+import * as Sandbox from "../common/sandbox";
+
+describe('app6 (label GRANTED_TO dev and harry, no root)', function () {
+    this.timeout(30000);
+    this.retries(3);
+
+    describe('super admin user', function () {
+        AppsHelpers.testInteractionsWithTerminal('john', 'app6');
+    });
+
+    describe('user harry', function () {
+        AppsHelpers.testInteractionsWithTerminal('harry', 'app6');
+    });
+
+    describe('user bob (in dev group)', function () {
+        AppsHelpers.testInteractionsWithTerminal('bob', 'app6');
+    });
+
+    describe('user alice (in devOPS & dev groups)', function () {
+        AppsHelpers.testInteractionsWithTerminal('alice', 'app6');
+    });
+
+    describe('user blackhat', function () {
+        AppsHelpers.testUnauthorizedUser('blackhat', 'app6');
+    });
+
+    describe("sandbox", () => {
+        describe('user john can open sandbox', () => {
+            Sandbox.testOpenSandbox('john', 'app6');
+        });
+
+        describe('user harry can open sandbox', () => {
+            Sandbox.testOpenSandbox('harry', 'app6');
+        });
+
+        describe('user bob can open sandbox', () => {
+            Sandbox.testOpenSandbox('bob', 'app6');
+        });
+
+        describe('user alice can open sandbox', () => {
+            Sandbox.testOpenSandbox('alice', 'app6');
+        });
+
+        describe('user blackhat is not authorized to open sandbox', () => {
+            Sandbox.testSandboxUnauthorized('blackhat', 'app6');
+        });
+    });
+});

--- a/tests/fullauthentication/docker-compose.yml
+++ b/tests/fullauthentication/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3"
+services:
+  mesos-term:
+    environment:
+      - MESOS_TERM_ENABLE_PER_APP_ADMINS=true
+      - MESOS_TERM_ENABLE_RIGHTS_DELEGATION=true
+      - MESOS_TERM_LDAP_URL=ldap://openldap
+      - MESOS_TERM_LDAP_BASE_DN=dc=example,dc=com
+      - MESOS_TERM_LDAP_USER=cn=admin,dc=example,dc=com
+      - MESOS_TERM_LDAP_PASSWORD=password
+      - MESOS_TERM_SUPER_ADMINS=admins
+      - SUITE=fullauthentication
+  mesos-slave:
+    environment:
+      MESOS_ACLS_PATH: "file:///etc/mesos/slave_acls.json"
+      MESOS_AUTHENTICATE_HTTP_READONLY: "true"
+    volumes:
+      - ./tests/resources/slave_acls.json:/etc/mesos/slave_acls.json

--- a/tests/resources/slave_acls.json
+++ b/tests/resources/slave_acls.json
@@ -1,0 +1,9 @@
+{
+  "permissive": true,
+  "access_sandboxes": [
+    {
+      "principals": { "values": ["admin"] },
+      "users": { "type": "ANY" }
+    }
+  ]
+}


### PR DESCRIPTION
Now we authenticate using configured principal when interacting with
mesos-slave api as well.
This will allow to deal with cases where all the api from mesos-slave is
authenticated.

Change-Id: Ifb11025e55a683873398d8de4442cc69640afaa0