### PR TITLE
Authorize everybody to delegate access

### DIFF
--- a/src/controllers/config.ts
+++ b/src/controllers/config.ts
@@ -4,9 +4,7 @@ import { env } from '../env_vars';
 import { isSuperAdmin } from '../authorizations';
 
 export default function (req: Request, res: Express.Response) {
-    const can_grant_access = (env.AUTHORIZATIONS_ENABLED)
-        ? isSuperAdmin(req.user.cn, req.user.memberOf, env.SUPER_ADMINS)
-        : false;
+    const can_grant_access = env.AUTHORIZATIONS_ENABLED;
 
     res.send({ can_grant_access });
 }

--- a/src/express_helpers.ts
+++ b/src/express_helpers.ts
@@ -54,6 +54,10 @@ export async function AllowConfiguredUsers(
 
   if (user.cn && user.memberOf) {
     try {
+      if (!req.body.task_id) {
+        res.status(406).send('Request must contain key `task_id`.');
+        return;
+      }
       const task_info = await getTaskInfo(req.body['task_id']);
       await CheckTaskAuthorization(req, task_info, undefined);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,7 @@ sandbox(app);
 app.get('/api/config', config);
 
 if (env.AUTHORIZATIONS_ENABLED && env.ENABLE_RIGHTS_DELEGATION) {
-  app.get('/api/delegate', AllowConfiguredUsers, DelegateGet);
+  app.get('/api/delegate', DelegateGet); // endpoint does not need authentication
   app.post('/api/delegate', AllowConfiguredUsers, DelegatePost);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import { DelegateGet, DelegatePost } from './controllers/delegate';
 import config from './controllers/config';
 import sandbox from './controllers/sandbox';
 
-import { setup, SuperAdminsOnly, AllowAnyOne } from './express_helpers';
+import { setup, SuperAdminsOnly, AllowConfiguredUsers } from './express_helpers';
 import { BasicAuth } from './authentication';
 import { AuthenticatedLogger, AnonymousLogger } from './logger';
 
@@ -60,8 +60,8 @@ sandbox(app);
 app.get('/api/config', config);
 
 if (env.AUTHORIZATIONS_ENABLED && env.ENABLE_RIGHTS_DELEGATION) {
-  app.get('/api/delegate', AllowAnyOne, DelegateGet);
-  app.post('/api/delegate', AllowAnyOne, DelegatePost);
+  app.get('/api/delegate', AllowConfiguredUsers, DelegateGet);
+  app.post('/api/delegate', AllowConfiguredUsers, DelegatePost);
 }
 
 app.get('*', (req, res) => {

--- a/src/views/delegate.ejs
+++ b/src/views/delegate.ejs
@@ -12,7 +12,7 @@
     following command:</p>
   <p style="border: 1px solid black; background-color: #ececec; padding: 20px; vertical-align: middle;">
     curl -u "<%= user %>" -XPOST -d '{"task_id": "XXXX", "delegate_to": "john", "duration": "1h"}' -H "Content-Type:
-    application/json" <%= url %>/delegate
+    application/json" <%= url %>/api/delegate
   </p>
 </body>
 

--- a/tests/standard/access_delegation.ts
+++ b/tests/standard/access_delegation.ts
@@ -17,11 +17,11 @@ describe('access delegation', function () {
     });
   });
 
-  it('should deny access to non super admin', function () {
+  it('should allow access to non super admin', function () {
     return helpers.withChrome(async function (driver) {
       await driver.get(`http://harry:password@localhost:3000/api/delegate`);
-      const el = await driver.wait(webdriver.until.elementLocated(webdriver.By.css(".error-code")), 5000);
-      return driver.wait(webdriver.until.elementTextContains(el, 'HTTP ERROR 403'), 5000);
+      const el = await driver.wait(webdriver.until.elementLocated(webdriver.By.css("p")), 5000);
+      return driver.wait(webdriver.until.elementTextContains(el, 'This endpoint allows'), 5000);
     });
   });
 

--- a/tests/standard/app2.ts
+++ b/tests/standard/app2.ts
@@ -17,10 +17,6 @@ describe('app2 (label GRANTED_TO harry, no root)', function () {
         AppsHelpers.testShouldSeeGrantAccessButton('john', 'app2');
     })
 
-    describe('grant access button is not displayed to harry', function () {
-        AppsHelpers.testShouldNotSeeGrantAccessButton('harry', 'app2');
-    })
-
     describe('user james is unauthorized', function () {
         AppsHelpers.testUnauthorizedUser('james', 'app2');
     });


### PR DESCRIPTION
This is a fixup for #133 which had several issues:
- a vulnerability: anyone could use the api directly to generate valid
  access token for any container as long they had valid creds (so they
  could bypass the authorization check).
- the "grant access" button was only visible to super admins

Now "grant access" button is always visible.

Change-Id: Ibae676c3f794cbc205bc5e928703140bed66eb6d