### PR TITLE
Find all tasks in mesos agent state

### DIFF
--- a/src/controllers/sandbox.ts
+++ b/src/controllers/sandbox.ts
@@ -68,6 +68,7 @@ const sandboxCache = cacheSandboxDescriptor(async (taskID) => {
     const slaveTaskInfos = await findTaskInSlaveState(slaveState, taskID);
 
     if (slaveTaskInfos.length === 0) {
+        console.log(`Task not found in slave state ${taskInfo.task_id}`);
         throw new TaskNotFoundError(taskID);
     }
 

--- a/src/mesos.ts
+++ b/src/mesos.ts
@@ -290,6 +290,7 @@ interface MesosSlaveState {
     work_dir: string;
   };
   frameworks: MesosSlaveFramework[];
+  completed_frameworks: MesosSlaveFramework[];
 }
 
 interface MesosSlaveExecutor {
@@ -318,10 +319,12 @@ export function findTaskInSlaveState(state: MesosSlaveState, taskID: string) {
     return acc2.concat(allExecutorTasks);
   };
 
-  const mesosTasks = state.frameworks
-    .reduce((acc: MesosTask[], framework: MesosSlaveFramework) => acc
+  const aggFrameworkTasks = (acc: MesosTask[], framework: MesosSlaveFramework) => acc
       .concat(framework.executors.reduce(aggExecutorTasks, []))
-      .concat(framework.completed_executors.reduce(aggExecutorTasks, [])), []);
+      .concat(framework.completed_executors.reduce(aggExecutorTasks, []));
+
+  const mesosTasks = state.frameworks.reduce(aggFrameworkTasks, [])
+    .concat(state.completed_frameworks.reduce(aggFrameworkTasks, []));
 
   return mesosTasks.filter(task => task.id === taskID);
 }


### PR DESCRIPTION
Before this patch, some tasks were marked as not found when trying to
explore dead tasks sandbox.
This was due to agent state being organized between `frameworks` and
`completed_frameworks`.
We now look for task info in all parts of the state and thus allow to
explore all dead tasks sandbox.

Change-Id: I20e675fd37ece6a37b6273134785ed5537c0cf49
JIRA: MESOS-4717